### PR TITLE
Add release notes from CHANGELOG.md to package

### DIFF
--- a/Std.UriTemplate.csproj
+++ b/Std.UriTemplate.csproj
@@ -52,7 +52,21 @@
   <ItemGroup>
     <None Include="..\Readme.md">
       <Pack>True</Pack>
-      <PackagePath></PackagePath>
+      <PackagePath>\</PackagePath>
+    </None>
+
+    <None Include="LICENSE">
+      <Pack>True</Pack>
+      <PackagePath>\</PackagePath>
     </None>
   </ItemGroup>
+
+  <Target Name="PreparePackageReleaseNotesFromFile" BeforeTargets="GenerateNuspec">
+    <ReadLinesFromFile File="CHANGELOG.md">
+      <Output TaskParameter="Lines" ItemName="ReleaseNoteLines" />
+    </ReadLinesFromFile>
+    <PropertyGroup>
+      <PackageReleaseNotes>@(ReleaseNoteLines, '%0a')</PackageReleaseNotes>
+    </PropertyGroup>
+  </Target>
 </Project>

--- a/Std.UriTemplate.csproj
+++ b/Std.UriTemplate.csproj
@@ -54,11 +54,6 @@
       <Pack>True</Pack>
       <PackagePath>\</PackagePath>
     </None>
-
-    <None Include="LICENSE">
-      <Pack>True</Pack>
-      <PackagePath>\</PackagePath>
-    </None>
   </ItemGroup>
 
   <Target Name="PreparePackageReleaseNotesFromFile" BeforeTargets="GenerateNuspec">


### PR DESCRIPTION
To complement the PR https://github.com/std-uritemplate/std-uritemplate/pull/203, this change will actually include the generated CHANGLOG in the NuGet package and show it on nuget.org.

I have also included the LICENSE because I noticed it was missing.